### PR TITLE
Adjust harness() CPUID assembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,18 +284,12 @@ See the `testmodule` folder for an example.
 ```
 static inline void harness(void)
 {
-    asm (
-        "push %rax\n\t"
-        "push %rbx\n\t"
-        "push %rcx\n\t"
-        "push %rdx\n\t"
-        "movq $0x13371337,%rax\n\t"
-        "cpuid\n\t"
-        "pop %rdx\n\t"
-        "pop %rcx\n\t"
-        "pop %rbx\n\t"
-        "pop %rax\n\t"
-    );
+    unsigned int tmp;
+
+    asm volatile ("cpuid"
+                  : "=a" (tmp)
+                  : "a" (0x13371337)
+                  : "bx", "cx", "dx");
 }
 ```
 

--- a/testmodule/testmodule.c
+++ b/testmodule/testmodule.c
@@ -5,18 +5,12 @@ static char test2[] = "nottbeef";
 
 static inline void harness(void)
 {
-    asm (
-        "push %rax\n\t"
-        "push %rbx\n\t"
-        "push %rcx\n\t"
-        "push %rdx\n\t"
-        "movq $0x13371337,%rax\n\t"
-        "cpuid\n\t"
-        "pop %rdx\n\t"
-        "pop %rcx\n\t"
-        "pop %rbx\n\t"
-        "pop %rax\n\t"
-    );
+    unsigned int tmp;
+
+    asm volatile ("cpuid"
+                  : "=a" (tmp)
+                  : "a" (0x13371337)
+                  : "bx", "cx", "dx");
 }
 
 static int path1(int x)


### PR DESCRIPTION
This only works as expected because asm() blocks with out no outputs are
considered implicity volatile.

Rewrite it using clobbers instead of explicit push/pop's (which the compiler
will arrange via register schedulling instead), which also makes the code
sequence work in 32bit mode as well as 64bit mode.

Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>