### PR TITLE
Change extended-mark to no_argument

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -204,7 +204,7 @@ int main(int argc, char** argv)
         {"ptcov", no_argument, NULL, 't'},
         {"detect-doublefetch", required_argument, NULL, 'D'},
         {"magic-mark", required_argument, NULL, 'm'},
-        {"extended-mark", required_argument, NULL, 'c'},
+        {"extended-mark", no_argument, NULL, 'c'},
         {"sink", required_argument, NULL, 'n'},
         {"sink-vaddr", required_argument, NULL, 'V'},
         {"sink-paddr", required_argument, NULL, 'P'},


### PR DESCRIPTION
"extended-mark" didn't require argument.
The usage didn't mention about the argument of "extended-mark", so I think it's a typo.