### PR TITLE
Add capture-vmcore

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -66,6 +66,12 @@ save_transplant_SOURCES = src/save-transplant-main.c src/save-transplant.c src/s
 save_transplant_LDADD = $(LIBS) $(VMI_LIBS) $(GLIB_LIBS)
 save_transplant_CFLAGS = $(CFLAGS) $(VMI_CFLAGS) $(GLIB_CFLAGS)
 
+bin_PROGRAMS +=  capture-vmcore
+capture_vmcore_SOURCES = src/capture-vmcore.c src/vmi.c src/vmi.h src/signal.c src/signal.h
+capture_vmcore_LDADD = $(LIBS) $(VMI_LIBS)
+capture_vmcore_CFLAGS = $(CFLAGS) $(VMI_CFLAGS)
+
+
 ACLOCAL_AMFLAGS=-I m4
 EXTRA_DIST = configure.ac README.md \
              patches/0001-AFL-Xen-mode.patch \

--- a/src/capture-vmcore.c
+++ b/src/capture-vmcore.c
@@ -1,0 +1,281 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * This tool fetches Linux vmcore from VMs that are paused at the beginning of a
+ * kernel crash (e.g oops_begin).
+ */
+#include <elf.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <getopt.h>
+#include <libvmi/libvmi.h>
+
+#include "vmi.h"
+#include "signal.h"
+
+
+addr_t target_pagetable;
+addr_t start_rip;
+os_t os;
+int interrupted, loopmode;
+page_mode_t pm;
+vmi_instance_t vmi;
+
+vmi_event_t interrupt_event;
+addr_t machine_kexec;
+uint8_t old_machine_kexec_insn;
+
+static void options(void)
+{
+    printf("Options:\n");
+    printf("\t--domain <domain name>\n");
+    printf("\t--domid <domain id>\n");
+    printf("\t--json <path to kernel debug json>\n");
+    printf("\t--out <path for output vmcore file>\n");
+}
+
+static event_response_t int3_cb(vmi_instance_t vmi, vmi_event_t *event)
+{
+    event->interrupt_event.reinject = 1;
+    if (event->interrupt_event.gla == machine_kexec)
+    {
+        vmi_write_8_va(vmi, machine_kexec, 0, &old_machine_kexec_insn);
+        vmi_pause_vm(vmi);
+        interrupted = 1;
+    }
+    return 0;
+}
+
+static bool resume_and_break_at_kexec(vmi_instance_t vmi)
+{
+    uint8_t cc = 0xcc;
+    SETUP_INTERRUPT_EVENT(&interrupt_event, int3_cb);
+    if ( (VMI_FAILURE == vmi_read_8_va(vmi, machine_kexec, 0, &old_machine_kexec_insn)) ||
+         (VMI_FAILURE == vmi_write_8_va(vmi, machine_kexec, 0, &cc)) ||
+         (VMI_FAILURE == vmi_register_event(vmi, &interrupt_event)) )
+    {
+        fprintf(stderr, "Failed to set a breakpoint at kexec\n");
+        return false;
+    }
+    loop(vmi);
+    return true;
+}
+
+static bool append_mem_to_file(vmi_instance_t vmi, addr_t pa, size_t size, FILE *out)
+{
+    static char buf[4096];
+    size_t total_read;
+    while ( total_read < size )
+    {
+        size_t to_read, read;
+        to_read = ( sizeof(buf) < size - total_read ) ? sizeof(buf) : size - total_read;
+        if ( (VMI_FAILURE == vmi_read_pa(vmi, pa + total_read, to_read, buf, &read)) ||
+            (to_read != read) )
+        {
+            fprintf(stderr, "Failed to read %d bytes at 0x%lx\n", size, pa);
+            return false;
+        }
+        fwrite(buf, to_read, 1, out);
+        total_read += read;
+    }
+    return true;
+}
+
+static bool dump_vmcore(vmi_instance_t vmi, addr_t elf_load_addr, addr_t elf_headers_sz, FILE *out)
+{
+    char elfcorehdr[elf_headers_sz];
+    Elf64_Ehdr *ehdr;
+    Elf64_Phdr *phdr;
+    int seg;
+    size_t read = 0, total_notes_memsz = 0;
+
+    if ( (VMI_FAILURE == vmi_read_pa(vmi, elf_load_addr, elf_headers_sz, elfcorehdr, &read)) ||
+         (elf_headers_sz != read) )
+    {
+        fprintf(stderr, "Failed to read ELF header at 0x%lx\n", elf_load_addr);
+        return false;
+    }
+
+    /*
+     * Skip the header for now. It will be modified a bit as we go.
+     */
+    fseek(out, elf_headers_sz, SEEK_SET);
+
+    ehdr = (Elf64_Ehdr*) elfcorehdr;
+    if (ehdr->e_machine != EM_X86_64)
+    {
+        fprintf(stderr, "Unexpected ELF machine type: %d\n", ehdr->e_machine);
+        return false;
+    }
+    phdr = (Elf64_Phdr*) &elfcorehdr[ehdr->e_phoff];
+
+    /*
+    * First squash all the PT_NOTE segments at the beginning of the list.
+    */
+    if ( ehdr->e_phnum > 0 && (PT_NOTE != phdr[0].p_type) )
+    {
+        fprintf(stderr, "Expected first program segment to be of type PT_NOTE\n");
+        return false;
+    }
+
+    phdr[0].p_offset = ftell(out);
+    for ( seg = 0; seg < ehdr->e_phnum && phdr[seg].p_type == PT_NOTE; ++seg )
+    {
+        Elf64_Nhdr nhdr;
+        size_t memsz = 0;
+
+        if ( VMI_FAILURE == vmi_read_pa(vmi, phdr[seg].p_paddr, sizeof(nhdr), &nhdr, &read) )
+        {
+            fprintf(stderr, "Failed to read %d bytes at 0x%lx\n", sizeof(nhdr), phdr[seg].p_paddr);
+            return false;
+        }
+        fwrite(&nhdr, sizeof(nhdr), 1, out);
+
+        memsz = sizeof(nhdr) + ((nhdr.n_namesz + 3) & ~3) + ((nhdr.n_descsz + 3) & ~3);
+        if ( !append_mem_to_file(vmi, phdr[seg].p_paddr + sizeof(nhdr), memsz - sizeof(nhdr), out) )
+            return false;
+        total_notes_memsz += memsz;
+    }
+    phdr[0].p_memsz = phdr[0].p_filesz = total_notes_memsz;
+    memmove(&phdr[1], &phdr[seg], (ehdr->e_phnum - seg) * sizeof(phdr[0]));
+    ehdr->e_phnum -= (seg - 1);
+
+    /*
+     * Next, copy all of the subsequent segments.
+     */
+    for ( seg = 1; seg < ehdr->e_phnum; ++seg )
+    {
+        phdr[seg].p_offset = ftell(out);
+        if ( phdr[seg].p_type == PT_NOTE )
+        {
+            fprintf(stderr, "Encountered a PT_NOTE segment in an unexpected location\n");
+            return false;
+        }
+        if ( !append_mem_to_file(vmi, phdr[seg].p_paddr, phdr[seg].p_memsz, out) )
+            return false;
+    }
+
+    /*
+     * Finally, write out the header.
+     */
+    fseek(out, 0, SEEK_SET);
+    fwrite(elfcorehdr, elf_headers_sz, 1, out);
+    return true;
+}
+
+int main(int argc, char** argv)
+{
+    vmi_instance_t vmi;
+    addr_t kexec_crash_image = 0, elf_load_addr = 0;
+    addr_t kimage_arch_offset = 0, elf_load_addr_offset = 0, elf_headers_sz_offset = 0;
+    size_t elf_headers_sz = 0;
+    FILE *out = NULL;
+    int c, long_index = 0;
+    const struct option long_opts[] =
+    {
+        {"domain", required_argument, NULL, 'd'},
+        {"domid", required_argument, NULL, 'i'},
+        {"json", required_argument, NULL, 'j'},
+        {"out", required_argument, NULL, 'o'},
+        {"help", no_argument, NULL, 'h'},
+        {NULL, 0, NULL, 0}
+    };
+    const char* opts = "d:i:j:h";
+    uint32_t domid = 0;
+    char *domain = NULL;
+    char *json;
+    char *outfile = NULL;
+
+    while ((c = getopt_long (argc, argv, opts, long_opts, &long_index)) != -1)
+    {
+        switch(c)
+        {
+        case 'd':
+            domain = optarg;
+            break;
+        case 'i':
+            domid = strtoul(optarg, NULL, 0);
+            break;
+        case 'j':
+            json = optarg;
+            break;
+        case 'o':
+            outfile = optarg;
+            break;
+        case 'h': /* fall-through */
+        default:
+            options();
+            return -1;
+        };
+    }
+
+    if ( (!domid && !domain) || !json || !outfile )
+    {
+        options();
+        return -1;
+    }
+
+    setup_handlers();
+
+    if ( !setup_vmi(&vmi, domain, domid, NULL, NULL, true, false) )
+    {
+        printf("Failed to enable LibVMI\n");
+        return -1;
+    }
+
+    if ( vmi_get_num_vcpus(vmi) > 1 )
+    {
+        printf("More than 1 vCPUs are not supported\n");
+        goto done;
+    }
+
+    if ( VMI_OS_LINUX != vmi_init_os(vmi, VMI_CONFIG_JSON_PATH, json, NULL) )
+    {
+        printf("Failed to initialize VMI for Linux\n");
+        goto done;
+    }
+
+    if ( (VMI_FAILURE == vmi_translate_ksym2v(vmi, "machine_kexec", &machine_kexec)) )
+    {
+        fprintf(stderr, "Cannot find the machine_kexec function\n");
+        goto done;
+    }
+
+    if ( (VMI_FAILURE == vmi_get_kernel_struct_offset(vmi, "kimage", "arch", &kimage_arch_offset)) ||
+         (VMI_FAILURE == vmi_get_kernel_struct_offset(vmi, "kimage_arch", "elf_load_addr", &elf_load_addr_offset)) ||
+         (VMI_FAILURE == vmi_get_kernel_struct_offset(vmi, "kimage_arch", "elf_headers_sz", &elf_headers_sz_offset)) )
+    {
+        fprintf(stderr, "Cannot find device kimage and/or elf_headers offsets\n");
+        goto done;
+    }
+    if ( (VMI_FAILURE == vmi_read_addr_ksym(vmi, "kexec_crash_image", &kexec_crash_image)) ||
+         (0 == kexec_crash_image) ||
+         VMI_FAILURE == vmi_read_addr_va(vmi, kexec_crash_image + kimage_arch_offset + elf_load_addr_offset, 0, &elf_load_addr) ||
+         (0 == elf_load_addr) ||
+         VMI_FAILURE == vmi_read_addr_va(vmi, kexec_crash_image + kimage_arch_offset + elf_headers_sz_offset, 0, &elf_headers_sz) ||
+         (0 == elf_headers_sz) )
+    {
+        fprintf(stderr, "Either kexec_crash_image or elf_load_addr was not found, or was found to be NULL\n");
+        fprintf(stderr, "Hint: Arm a kdump kernel with 'kexec -p' before running kfx --setup\n");
+        goto done;
+
+    }
+    printf("Found vmcore ELF header at PA 0x%lx\n", elf_load_addr);
+    printf("Resuming VM until kdump kexec to populate/update all segments\n");
+    if ( !resume_and_break_at_kexec(vmi) )
+        goto done;
+    out = fopen(outfile, "w+");
+    printf("Dumping vmcore. This may take some time...\n");
+    if ( !dump_vmcore(vmi, elf_load_addr, elf_headers_sz, out) )
+        goto done;
+    printf("Successfully dumped vmcore to %s\n", outfile);
+
+done:
+    if ( out )
+        fclose(out);
+    vmi_destroy(vmi);
+
+    return 0;
+}

--- a/src/capture-vmcore.c
+++ b/src/capture-vmcore.c
@@ -266,8 +266,8 @@ int main(int argc, char** argv)
     printf("Resuming VM until kdump kexec to populate/update all segments\n");
     if ( !resume_and_break_at_kexec(vmi) )
         goto done;
+    umask(S_IWGRP|S_IWOTH);
     out = fopen(outfile, "w+");
-    chmod(outfile, 0644);
     printf("Dumping vmcore. This may take some time...\n");
     if ( !dump_vmcore(vmi, elf_load_addr, elf_headers_sz, out) )
         goto done;

--- a/src/main.c
+++ b/src/main.c
@@ -494,6 +494,8 @@ int main(int argc, char** argv)
         }
     }
 
+    if ( keep )
+        teardown_sinks(vmi);
     close_trace(vmi);
     vmi_destroy(vmi);
 

--- a/src/sink.h
+++ b/src/sink.h
@@ -12,6 +12,7 @@ struct sink {
     addr_t vaddr;
     addr_t paddr;
     struct sink_handler *handler;
+    uint8_t old_insn;
 };
 
 /*

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -9,6 +9,7 @@
 #include <libvmi/libvmi.h>
 
 bool make_sink_ready(void);
+void teardown_sinks(vmi_instance_t vmi);
 
 bool setup_trace(vmi_instance_t vmi);
 bool start_trace(vmi_instance_t vmi, addr_t address);


### PR DESCRIPTION
This tool can be used to capture vmcore from VMs that are paused at a kernel crash sink. This vmcore is similar to what a kdump kernel would present under /proc/vmcore and is compatible with all associated tools such as makedumpfile, crash, etc.

The VM kernel just needs to have an arbitrary kdump kernel loaded. However we do not depend on that kernel. The kexec doesn't need to be successful and the tool doesn't need a second .json corresponding to the kdump kernel.

NB: I did try xl dump-core but did not have any luck making it work the same way. Apart from dump-core not working on forked VMs, I also had problems with test dumps from parent VMs. crash @HEAD segfaults even though I think it supports the format on paper. makedumpfile compression is also a neat feature that I couldn't replicate with Xen dumps. 