### PR TITLE
Give VM forks friendly and identifiable names

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,10 +13,10 @@ if WITH_XEN
                     src/ptcov.c src/ptcov.h \
                     src/kasan_handler.c \
                     src/sink.h src/sink_handler.h
-    kfx_LDADD   = $(LIBS) $(VMI_LIBS) $(CAPSTONE_LIBS) $(LIBXC_LIBS) $(XENFMEM_LIBS) $(GLIB_LIBS)
+    kfx_LDADD   = $(LIBS) $(VMI_LIBS) $(CAPSTONE_LIBS) $(LIBXC_LIBS) $(LIBXL_LIBS) $(XENFMEM_LIBS) $(GLIB_LIBS)
     kfx_CFLAGS  = -Wall -Wextra -fstack-protector -Wno-override-init -Wno-unused-variable \
               -DCODECOV_SIGNAL \
-              $(CFLAGS) $(VMI_CFLAGS) $(CAPSTONE_CFLAGS) $(LIBXC_CFLAGS) $(XENFMEM_CFLAGS) $(GLIB_CFLAGS)
+              $(CFLAGS) $(VMI_CFLAGS) $(CAPSTONE_CFLAGS) $(LIBXC_CFLAGS) $(LIBXL_CFLAGS) $(XENFMEM_CFLAGS) $(GLIB_CFLAGS)
 
 if STATIC_LIBXDC
         noinst_LTLIBRARIES= libxdc.la
@@ -30,8 +30,8 @@ endif
 
     bin_PROGRAMS += forkvm
     forkvm_SOURCES = src/forkvm_main.c src/forkvm.c src/forkvm.h
-    forkvm_LDADD = $(LIBXC_LIBS)
-    forkvm_CFLAGS = $(LIBXC_CFLAGS)
+    forkvm_LDADD = $(LIBXC_LIBS) $(LIBXL_LIBS)
+    forkvm_CFLAGS = $(LIBXC_CFLAGS) $(LIBXL_CFLAGS)
 
     bin_PROGRAMS += xen-transplant
     xen_transplant_SOURCES = src/xen-transplant.c

--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,7 @@ AC_ARG_ENABLE([xen],
 
 AS_IF([test x"$with_xen" = x"yes"], [
     PKG_CHECK_MODULES([LIBXC], [xencontrol >= 4.15.0],[],[AC_MSG_ERROR(libxc not found. Install missing package and re-run)])
+    PKG_CHECK_MODULES([LIBXL], [xenlight >= 4.15.0],[],[AC_MSG_ERROR(libxenlight not found. Install missing package and re-run)])
     PKG_CHECK_MODULES([XENFMEM], [xenforeignmemory >= 1.3],[],[AC_MSG_ERROR(libxenforeignmemory not found. Install missing package and re-run)])
     AC_CHECK_HEADERS([libxl.h], [], [AC_MSG_ERROR(libxl.h not found. Install missing package and re-run)])
     AC_CHECK_HEADERS([xen/xen.h], [], [AC_MSG_ERROR(xen/xen.h not found. Install missing package and re-run)])

--- a/src/forkvm.h
+++ b/src/forkvm.h
@@ -8,7 +8,8 @@
 #include <xenctrl.h>
 #define LIBXL_API_VERSION 0x041300
 #include <libxl.h>
+#include <libxl_utils.h>
 
-bool fork_vm(uint32_t domid, uint32_t *forkdomid);
+bool fork_vm(uint32_t domid, char *name_sig, char *name_flavor, uint32_t *forkdomid);
 
 #endif

--- a/src/forkvm_main.c
+++ b/src/forkvm_main.c
@@ -7,6 +7,7 @@
 #include "forkvm.h"
 
 xc_interface *xc;
+libxl_ctx *xl;
 xc_dominfo_t info;
 int vcpus;
 uint32_t domid, forkdomid;
@@ -21,6 +22,8 @@ int main(int argc, char** argv)
 
     if ( !(xc = xc_interface_open(0, 0, 0)) )
         return -1;
+    if ( libxl_ctx_alloc(&xl, LIBXL_VERSION, 0, NULL) )
+        xl = NULL;
 
     domid = atoi(argv[1]);
 
@@ -28,12 +31,17 @@ int main(int argc, char** argv)
     {
         vcpus = ++info.max_vcpu_id;
 
-        if ( fork_vm(domid, &forkdomid) )
+        if ( fork_vm(domid, NULL, "forkvm", &forkdomid) )
             printf("Fork VM id: %u\n", forkdomid);
         else
             printf("Forking VM %u failed\n", domid);
     }
 
+    if ( xl )
+    {
+        libxl_ctx_free(xl);
+        xl = NULL;
+    }
     xc_interface_close(xc);
     return 0;
 }

--- a/src/private.c
+++ b/src/private.c
@@ -13,6 +13,7 @@ size_t input_size;
 size_t input_limit;
 unsigned char *input;
 uint32_t domid, sinkdomid, fuzzdomid;
+char* fork_sig;
 bool afl;
 bool parent_ready;
 bool crash;
@@ -29,6 +30,7 @@ GHashTable *codecov;
 GHashTable *memaccess;
 
 xc_interface *xc;
+libxl_ctx *xl;
 vmi_instance_t parent_vmi, vmi;
 os_t os;
 addr_t target_pagetable;

--- a/src/private.h
+++ b/src/private.h
@@ -35,6 +35,7 @@ extern size_t input_size;
 extern size_t input_limit;
 extern unsigned char *input;
 extern uint32_t domid, sinkdomid, fuzzdomid;
+extern char* fork_sig;
 extern bool afl;
 extern bool parent_ready;
 extern bool crash;
@@ -51,6 +52,7 @@ extern GHashTable *codecov;
 extern GHashTable *memaccess;
 
 extern xc_interface *xc;
+extern libxl_ctx *xl;
 extern vmi_instance_t vmi;
 extern os_t os;
 extern addr_t target_pagetable;


### PR DESCRIPTION
Uses libxenlight (new dependency) to rename sink and fuzzing forks.
Names are derived from the (grand)parent VM but a user specified token
(-G) will also be mixed in if specified. The usecase for -G is to be
able to easily idendify VM forks when triaging a set of crashing
inputs with --keep.
fork's domid is used in place if -G is not specified.

Example VM names:

For kfx without -G:
debian-1-sink-2
debian-1-fuzz-3

For kfx with -G id:000000:
debian-1-sink-id:000000
debian-1-fuzz-id:000000

For forkvm:
debian-1-forkvm-2