### PR TITLE
Set libxdc IP callback even if not in debug mode

### DIFF
--- a/src/ptcov.c
+++ b/src/ptcov.c
@@ -140,6 +140,8 @@ bool setup_pt(void)
 
     if ( debug || record_codecov )
         libxdc_register_ip_callback(decoder, &ip_cb, NULL);
+    else
+        libxdc_register_ip_callback(decoder, NULL, NULL);
 
     return true;
 }


### PR DESCRIPTION
The current libxdc submodule version doesn't initialize the `ip_callback` member of the decoder. This is a workaround, that sets the callback pointer to NULL if we're not in debug mode or collecting coverage, so libxdc can recognize it's invalid before call. 

I didn't report this to libxdc because their current version seems to have refactored this code completely. 

This seems to fix #60 .